### PR TITLE
New method of banning (cleaner)

### DIFF
--- a/main.py
+++ b/main.py
@@ -15,67 +15,62 @@ MSG = "¡Te damos la bienvenida{}! En el mensaje anclado tienes las reglas bási
 
 URI_MAIL = r'[/@]WORD(\.WORD)'.replace('WORD', '[^\s.]+')
 BAN_RULES = (
-    (lambda name: len(name) > 30, "id={} member ban by: long name"),
-    (re.compile(URI_MAIL).search, "id={} member ban by: name with url/uri/email"),
+    (lambda name: len(name) > 30, "id={} member in id={} group ban by: long name"),
+    (re.compile(URI_MAIL).search, "id={} member in id={} group ban by: name with url/uri/email"),
 )
+NOT_BAN_MSG = "id={} member in id={} group can not ban: {}"
 
 logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
 
 
-def ban_member(bot, update, user):
-    chat_id = update.message.chat_id
-    user_id = user.id
+def ban_member(bot, update, user, reason):
+    chat = update.message.chat
 
-    kicked = bot.kick_chat_member(chat_id=chat_id, user_id=user_id)
-    if kicked:
-        catheter = bot.sendMessage(chat_id=chat_id, text="Member kicked")
+    all_adm = chat.all_members_are_administrators
+    bot_adm = any(m.user.id == bot.id for m in chat.get_administrators())
 
-        id1 = update.message.message_id  # Identification of the join message
-        id3 = catheter.message_id        # Identification of the catheter message :)
-        id2 = id3 - 1                    # Identification of the kicked message (potential)
-
-        for i in range(id2, id1, -1):
-            # Reply
-            m = bot.sendMessage(chat_id=chat_id, text="reply", reply_to_message_id=i)
-            l = m.reply_to_message.left_chat_member
-            if l and l.id == user_id:
-                # Kicked message!
-                bot.delete_message(chat_id=chat_id, message_id=m.reply_to_message.message_id)
-            # Delete reply message
-            bot.delete_message(chat_id=chat_id, message_id=m.message_id)
-
-        # Delete join and catheter messages
-        bot.delete_message(chat_id=chat_id, message_id=id1)
-        bot.delete_message(chat_id=chat_id, message_id=id3)
+    if bot_adm and not all_adm:
+        kicked = chat.kick_member(user_id=user.id)
+        if kicked:
+            update.message.delete()  # new_chat_members messages
+            logger.debug(reason.format(user.id, chat.id))
+        else:
+            cause = "unknown"
+            logger.debug(NOT_BAN_MSG.format(user.id, chat.id, cause))
     else:
-        logger.error("The id={} member could not be banned".format(user_id))
+        cause = "requirements are not met"
+        logger.debug(NOT_BAN_MSG.format(user.id, chat.id, cause))
 
 
 def new_user(bot, update):
     message_texts = []
     for user in (update.message.new_chat_members or [update.message.from_user]):
-        name = user.first_name or user.last_name or user.username
+        name = user.first_name or user.last_name or user.username or ""
         greet = True
         if name:
             for rule, reason in BAN_RULES:
                 if rule(name):
-                    ban_member(bot, update, user)
-                    logger.debug(reason.format(user.id))
+                    ban_member(bot, update, user, reason)
                     greet = False
                     break
             else:
                 name = ", {}".format(name)
-        else:
-            name = ""
         if greet and not user.is_bot:
             message_texts.append(MSG.format(name))
     if message_texts:
-        bot.sendMessage(chat_id=update.message.chat_id, text='\n'.join(message_texts))
+        update.message.chat.send_message(text='\n'.join(message_texts))
+
+
+def bye_user(bot, update):
+    if update.message.from_user.id == bot.id:
+        update.message.delete()  # left_chat_member messages from kick
+
 
 def start(bot, update):
     bot.send_message(chat_id=update.message.chat_id, text="I'm a bot, please talk to me!")
+
 
 def main():
     updater = Updater(TOKEN)
@@ -86,6 +81,7 @@ def main():
         dp.add_handler(CommandHandler('start', start))
 
     dp.add_handler(MessageHandler(Filters.status_update.new_chat_members, new_user))
+    dp.add_handler(MessageHandler(Filters.status_update.left_chat_member, bye_user))
 
     # Ignore all messages until it is called
     #updater.start_polling(clean=True)


### PR DESCRIPTION
Now if the service message (expulsion) arrives at the bot doing the expulsion (according to the doc all service messages should be sent to the bots).

Now the bot receives an income (new_chat_members), applies the ban rules, if applicable it executes the expulsion and does not greet. When executing the expulsion another message arrives (left_chat_member) that is eliminated (this is the bug fixed by telegram).

Also add a check, so the bot does not try to ban someone without having permissions.

URL detection is still poor, because all the top-level domain (TLD) would have to be loaded in a check. But it seems to work very well so far, the biggest problem was the length of the names.